### PR TITLE
Fix gradient planet titles and update socials modal

### DIFF
--- a/css/modals.css
+++ b/css/modals.css
@@ -532,26 +532,13 @@
 /* Modal Social Links */
 .modal-social {
   margin-top: 2rem;
-  padding-top: 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.modal-social .social-section {
-  margin-bottom: 1.5rem;
-}
-
-.modal-social .social-section:last-child {
-  margin-bottom: 0;
-}
-
-.modal-social h4 {
-  font-size: 1rem;
-  font-weight: 600;
-  margin-bottom: 0.75rem;
-  color: rgba(255, 255, 255, 0.9);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+.modal-social-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 .modal-social .social-btn {
@@ -579,6 +566,9 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 1.5rem;
+  justify-content: center;
 }
 
 .modal-social .social-link {
@@ -609,9 +599,8 @@
 @media (max-width: 768px) {
   .modal-social {
     margin-top: 1.5rem;
-    padding-top: 1.5rem;
   }
-  
+
   .modal-social .social-btn {
     padding: 0.6rem 1.2rem;
     font-size: 0.85rem;
@@ -624,6 +613,7 @@
   
   .modal-social .social-links {
     gap: 0.5rem;
+    padding-top: 1rem;
   }
 }
 

--- a/css/zoom-system.css
+++ b/css/zoom-system.css
@@ -149,16 +149,25 @@
 .zoom-container.dev .zoom-planet-title,
 .zoom-container.dev .zoom-planet-subtitle {
   background: linear-gradient(135deg, #00f5ff, #00b4c8);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .zoom-container.media .zoom-planet-title,
 .zoom-container.media .zoom-planet-subtitle {
   background: linear-gradient(135deg, #b100ff, #6d00b3);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .zoom-container.learn .zoom-planet-title,
 .zoom-container.learn .zoom-planet-subtitle {
   background: linear-gradient(135deg, #ffb100, #ff6b00);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 /* Orbital system */

--- a/js/zoom-system.js
+++ b/js/zoom-system.js
@@ -374,7 +374,7 @@ class ZoomSystem {
         <button class="modal-close" aria-label="Close socials"><i class="fas fa-times"></i></button>
         <div class="modal-body">
           <div class="modal-social">
-            <h4>Explore our social media</h4>
+            <h3 class="modal-social-title text-gradient">Explore our socials</h3>
             <div class="social-links">
               <a href="${data.telegram}" class="social-link" target="_blank">
                 <i class="fab fa-telegram-plane"></i>


### PR DESCRIPTION
## Summary
- ensure zoom titles use proper gradient text for each planet
- move socials heading above divider with cosmic gradient styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dbd3372208330af4fcce766ed79b2